### PR TITLE
Fix: Use Search URL instead of Repository detail URL

### DIFF
--- a/Week6/MAKEME.md
+++ b/Week6/MAKEME.md
@@ -36,7 +36,7 @@ Cool we are back where we left of.
 https://api.github.com/repos/HackYourFuture/CommandLine
 ```
 
-7) Make a function which takes a single argument. The function should make an XHR request to `https://api.github.com/repos/HackYourFuture/[SearchTerm]` where the search term will be the argument. This argument will be the input the user has given you, so make sure that when the user clicks the button you call this function with the argument. 
+7) Make a function which takes a single argument. The function should make an XHR request to `https://api.github.com/search/repositories?q=user:HackYourFuture+[SearchTerm]` where the search term will be the argument. This argument will be the input the user has given you, so make sure that when the user clicks the button you call this function with the argument. 
 
 8) Make all the repositories link their own page in Github. Use the value of the key: `name` to make this work (hint: Github urls always look like this https://api.github.com/repos/HackYourFuture/[repositoryName] where [repositoryName] would be replaced by the actual `name` of the repository, for example `CommandLine`). Make sure the link opens in a new tab.
 
@@ -44,7 +44,6 @@ https://api.github.com/repos/HackYourFuture/CommandLine
 
 So Github has this really nice documentation :octocat: :
 Check these out for example
-https://developer.github.com/v3/repos/collaborators/
 https://developer.github.com/v3/repos/commits/
 
 9) Extend your page with an input element. This is so the user will be able to type in text.


### PR DESCRIPTION
- Students will need to use URL of Search API of Github to implement search in their homework.
- Github API does not allow everyone to list collaborators of a repo. Not even using an API Key. You need to have access to the repository as a collaborator for that.

Sample app - https://plnkr.co/edit/wRDlytMfwyLBmxprUgcN?p=preview