### PR TITLE
Fix shipsToHTML to be valid HTML

### DIFF
--- a/javascript2/week2/homework/hyf-bay/main.js
+++ b/javascript2/week2/homework/hyf-bay/main.js
@@ -8,7 +8,8 @@ function renderProducts(products) {
     products.forEach(product => {
         const li = document.createElement('li');
 
-        const shipsToHTML = product.shipsTo.reduce((acc, country) => `<li>${acc}</li><li>${country}</li>`);
+        let shipsToHTML = '';
+        product.shipsTo.forEach(country => shipsToHTML += `<li>${country}</li>`);
 
         li.innerHTML = `
             <ul>


### PR DESCRIPTION
I was about to give feedback to a student that their `shipsToHTML` was not entirely correct until I noticed that it is in the base implementation.

Basically `shipsToHTML` will only contain valid HTML if the product is shipped to 2 countries.
For the case of 1 country there is not wrapping `<li>`.
And for the other cases the `<li>`s will be unintentionally nested.

This is the output of `console.log('shipsToHTML', shipsToHTML);`:

<img width="481" alt="Screenshot 2019-10-21 at 21 47 56" src="https://user-images.githubusercontent.com/809707/67237927-7f2f2a00-f44c-11e9-938d-766515cdc39b.png">
